### PR TITLE
Remove file default value to prevent warning

### DIFF
--- a/updatedata.php
+++ b/updatedata.php
@@ -24,7 +24,7 @@ $user=mysqli_fetch_assoc($query);
         <form class="form form-responsive" action="editdata.php?id=<?php echo $id;?>" method="post" enctype="multipart/form-data">
             <input class="form-control mt-2" type="text" placeholder="Enter your name" value="<?php echo $user['username'];?>" name="username" required>
             <input class="form-control mt-2" type="number" placeholder="Enter your Roll number" value="<?php echo $user['roll'];?>" name="roll" required>
-            <input class="form-control mt-2" type="file" value="<?php echo $user['file'];?>" name="file" required>
+            <input class="form-control mt-2" type="file" name="file" required>
             <input class="form-control mt-2 bg-warning" type="submit" name="btn" value="Update">
         </form>
     </div>


### PR DESCRIPTION
In php version 7.4 it is showing an warning.

![image](https://user-images.githubusercontent.com/29161993/137589555-f75d4838-3564-4a60-8620-a98e41693cb4.png)
